### PR TITLE
Add alt operator

### DIFF
--- a/src/io/lvh/silly_solve.cljc
+++ b/src/io/lvh/silly_solve.cljc
@@ -27,11 +27,7 @@
    {::symbol 'min ::fn min ::commutative true}
    {::symbol 'floor ::fn floor}
    {::symbol 'ceil ::fn ceil}
-   ;; TODO: decide whether to use `alt` or `or` as the operator
-   ;; name here. `or` is easier for a non-programmer to understand than
-   ;; `alt`, but is less precise because silly-solve doesn't have full-fledged
-   ;; Boolean logic
-   {::symbol 'or ::fn alt}])
+   {::symbol 'alt ::fn alt}])
 
 (def ^:private op-sym?
   (into #{} (map ::symbol) ops))
@@ -107,7 +103,7 @@
      (* 1 ?x) ?x
      ('** 1 ?x) ?x ;; unquoted `**` would be interpreted as memory variable `*`
 
-     ('or ?x) ?x
+     ('alt ?x) ?x
 
      ;; Remove tautologies & meaningless unary equalities
      (= & (m/pred (fn [args] (or (empty? args) (apply = args))) ?args)) nil

--- a/src/io/lvh/silly_solve.cljc
+++ b/src/io/lvh/silly_solve.cljc
@@ -14,8 +14,8 @@
 (def variable? (some-fn symbol? keyword?))
 
 (defn alt
- "alt: first non-nil value of the passed args"
- [& args] (first (filter some? args)))
+ "alt: first non-zero value of the passed args"
+ [& args] (first (filter #(not (zero? %)) args)))
 
 (def ^:private ops
   [{::symbol '+ ::fn + ::commutative true}

--- a/src/io/lvh/silly_solve.cljc
+++ b/src/io/lvh/silly_solve.cljc
@@ -13,6 +13,10 @@
 
 (def variable? (some-fn symbol? keyword?))
 
+(defn alt
+ "alt: first non-nil value of the passed args"
+ [& args] (first (filter some? args)))
+
 (def ^:private ops
   [{::symbol '+ ::fn + ::commutative true}
    {::symbol '* ::fn * ::commutative true}
@@ -22,7 +26,12 @@
    {::symbol 'max ::fn max ::commutative true}
    {::symbol 'min ::fn min ::commutative true}
    {::symbol 'floor ::fn floor}
-   {::symbol 'ceil ::fn ceil}])
+   {::symbol 'ceil ::fn ceil}
+   ;; TODO: decide whether to use `alt` or `or` as the operator
+   ;; name here. `or` is easier for a non-programmer to understand than
+   ;; `alt`, but is less precise because silly-solve doesn't have full-fledged
+   ;; Boolean logic
+   {::symbol 'or ::fn alt}])
 
 (def ^:private op-sym?
   (into #{} (map ::symbol) ops))
@@ -97,6 +106,8 @@
      (+ 0 ?x) ?x
      (* 1 ?x) ?x
      ('** 1 ?x) ?x ;; unquoted `**` would be interpreted as memory variable `*`
+
+     ('or ?x) ?x
 
      ;; Remove tautologies & meaningless unary equalities
      (= & (m/pred (fn [args] (or (empty? args) (apply = args))) ?args)) nil

--- a/src/io/lvh/silly_solve.cljc
+++ b/src/io/lvh/silly_solve.cljc
@@ -15,7 +15,7 @@
 
 (defn alt
  "alt: first non-zero value of the passed args"
- [& args] (first (filter #(not (zero? %)) args)))
+ [& args] (first (remove zero? args)))
 
 (def ^:private ops
   [{::symbol '+ ::fn + ::commutative true}

--- a/test/io/lvh/silly_solve_generative_test.clj
+++ b/test/io/lvh/silly_solve_generative_test.clj
@@ -573,3 +573,88 @@
       (op-result pass?
                  {:expr expr :simplified simplified :expected a :actual result-val}
                  #(simplify-with-trace expr)))))
+
+;; =============================================================================
+;; Alt operator properties
+;; =============================================================================
+
+(def gen-alt-args
+  "Generator for alt arguments: a mix of zeros and non-zero rationals."
+  (gen/vector (gen/frequency [[1 (gen/return 0)]
+                              [2 gen-nonzero-rational]])
+              1 6))
+
+(def gen-all-zeros
+  "Generator for a vector of zeros."
+  (gen/vector (gen/return 0) 1 6))
+
+(def gen-alt-with-nonzero
+  "Generator for alt arguments guaranteed to have at least one non-zero."
+  (gen/let [before-zeros (gen/vector (gen/return 0) 0 3)
+            nonzero gen-nonzero-rational
+            after (gen/vector (gen/frequency [[1 (gen/return 0)]
+                                              [1 gen-nonzero-rational]])
+                              0 3)]
+    (vec (concat before-zeros [nonzero] after))))
+
+(defspec alt-returns-first-nonzero 500
+  (prop/for-all [args gen-alt-with-nonzero]
+    (let [result (apply ss/alt args)
+          expected (first (remove zero? args))
+          pass? (= result expected)]
+      (op-result pass?
+                 {:args args :result result :expected expected}
+                 (constantly nil)))))
+
+(defspec alt-result-is-member-of-inputs 500
+  (prop/for-all [args gen-alt-args]
+    (let [result (apply ss/alt args)
+          pass? (or (nil? result)
+                    (some #(= result %) args))]
+      (op-result pass?
+                 {:args args :result result}
+                 (constantly nil)))))
+
+(defspec alt-all-zeros-yields-nil 500
+  (prop/for-all [args gen-all-zeros]
+    (let [result (apply ss/alt args)
+          pass? (nil? result)]
+      (op-result pass?
+                 {:args args :result result}
+                 (constantly nil)))))
+
+(defspec alt-unary-nonzero-returns-arg 500
+  (prop/for-all [x gen-nonzero-rational]
+    (let [result (ss/alt x)
+          pass? (= result x)]
+      (op-result pass?
+                 {:arg x :result result}
+                 (constantly nil)))))
+
+(defspec alt-unary-zero-returns-nil 500
+  (prop/for-all [_ (gen/return nil)]
+    (let [result (ss/alt 0)
+          pass? (nil? result)]
+      (op-result pass?
+                 {:result result}
+                 (constantly nil)))))
+
+;; Test that alt simplifies correctly in expressions
+(def gen-alt-expr
+  "Generator for alt expressions with constants."
+  (gen/let [args gen-alt-with-nonzero]
+    (cons 'alt args)))
+
+(defspec alt-simplify-preserves-semantics 500
+  (prop/for-all [args gen-alt-with-nonzero]
+    (let [expr (cons 'alt args)
+          simplified (try-simplify expr)
+          expected (first (remove zero? args))
+          ;; After simplification, result should equal the first non-zero
+          pass? (or (nil? simplified)
+                    (= simplified expected)
+                    (and (number? simplified)
+                         (approximately= simplified expected)))]
+      (op-result pass?
+                 {:expr expr :simplified simplified :expected expected}
+                 #(simplify-with-trace expr)))))

--- a/test/io/lvh/silly_solve_test.clj
+++ b/test/io/lvh/silly_solve_test.clj
@@ -241,3 +241,11 @@
 
   (t/testing "simpler reproduction: (* 25 1) should equal 25, not 50"
     (t/is (= 25 (ss/simplify '(* 25 1))))))
+
+(t/deftest alternative
+  (let [solved (ss/solve-for-consts
+                '[(= :result (or nil 1))
+                  (= :result2 (or 2 nil))])]
+    (println solved)
+    (t/is (= [[] {:result 1 :result2 2}]
+             solved))))

--- a/test/io/lvh/silly_solve_test.clj
+++ b/test/io/lvh/silly_solve_test.clj
@@ -246,7 +246,7 @@
 (t/deftest alternative
   (let [[eqs vs :as solved]
         (ss/solve-for-consts
-         '[(= :result (or 0 1))
-           (= :result2 (or 2 0))])]
+         '[(= :result (alt 0 1))
+           (= :result2 (alt 2 0))])]
     (t/is (= {:result 1 :result2 2}
              vs))))

--- a/test/io/lvh/silly_solve_test.clj
+++ b/test/io/lvh/silly_solve_test.clj
@@ -242,11 +242,19 @@
   (t/testing "simpler reproduction: (* 25 1) should equal 25, not 50"
     (t/is (= 25 (ss/simplify '(* 25 1))))))
 
-
 (t/deftest alternative
   (let [[eqs vs :as solved]
         (ss/solve-for-consts
-         '[(= :result (alt 0 1))
-           (= :result2 (alt 2 0))])]
-    (t/is (= {:result 1 :result2 2}
-             vs))))
+         '[(= :result1 (alt 0 1))
+           (= :result2 (alt 2 0))
+           (= :result3 (+ 1 (alt 2 0)))
+           (= :result4 (* 2 (alt 2 0)))
+           (= :result5 (+ (alt 2 0) (alt 0 0 0 0 0 3)))
+           (= :result6 (alt (* :result2 :result3) 0))
+           (= :result7 (alt (+ :result6 1)  3))])]
+    (t/is (= {:result1 1 :result2 2
+              :result3 3 :result4 4
+              :result5 5 :result6 6
+              :result7 7}
+             vs)
+          "alt operator should allow for finding non-zero values and ordered choice among options")))

--- a/test/io/lvh/silly_solve_test.clj
+++ b/test/io/lvh/silly_solve_test.clj
@@ -242,10 +242,11 @@
   (t/testing "simpler reproduction: (* 25 1) should equal 25, not 50"
     (t/is (= 25 (ss/simplify '(* 25 1))))))
 
+
 (t/deftest alternative
-  (let [solved (ss/solve-for-consts
-                '[(= :result (or nil 1))
-                  (= :result2 (or 2 nil))])]
-    (println solved)
-    (t/is (= [[] {:result 1 :result2 2}]
-             solved))))
+  (let [[eqs vs :as solved]
+        (ss/solve-for-consts
+         '[(= :result (or 0 1))
+           (= :result2 (or 2 0))])]
+    (t/is (= {:result 1 :result2 2}
+             vs))))


### PR DESCRIPTION
The `alt` operator may be the simplest way of expressing ordered choice among variables/solutions, which is useful for "fallback" operations in case something gets multiplied by zero and needs to find a default value.

Defined here as "first non-zero value" to avoid implying that it's the same as "or". This capability doesn't need a full-fledged Boolean logic system to work, and it also ensures that none of the core operations have to become `nil`-aware: it's still numeric instead of logical.